### PR TITLE
feat: return decoding errors

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,9 +21,12 @@ fn encode_from_buffer(c: &mut Criterion) {
 fn decode(c: &mut Criterion) {
     c.bench_function("decode long string", |b| {
         b.iter(|| {
-            String::from_utf8(base45::decode(black_box(
-                "8UADZCKFEOEDJOD2KC54EM-DX.CH8FSKDQ$D.OE44E5$CS44+8DK44OEC3EFGVCD2",
-            )))
+            String::from_utf8(
+                base45::decode(black_box(
+                    "8UADZCKFEOEDJOD2KC54EM-DX.CH8FSKDQ$D.OE44E5$CS44+8DK44OEC3EFGVCD2",
+                ))
+                .unwrap(),
+            )
             .unwrap()
         })
     });


### PR DESCRIPTION
To use `base64::decode()` with user-supplied input, the input validation using panics is rather limiting. By returning a `Result<_,_>` decoding errors can be handled gracefully. This should not have a performance impact but is a breaking change.